### PR TITLE
Buggy finaliseTemplate

### DIFF
--- a/src/Mustache.php
+++ b/src/Mustache.php
@@ -135,11 +135,14 @@ class Mustache
 
             // ----------------------------------
 
-            elseif (is_bool($val) || empty($val) === true)
+            elseif (is_bool($val) || is_array($val) && empty($val) === true)
             {
                 // determine true/false
                 $conditionChar = $val === true ? '\#' : '\^';
+                $negationChar = $val === true ? '\^' : '\#';
 
+                // remove bools
+                $template = preg_replace('|{{' . $negationChar . $key . '}}.*?{{/' . $key . '}}\n*|s', '', $template);
                 // find bools
                 preg_match_all('|{{' . $conditionChar . $key . '}}(.*?){{/' . $key . '}}|s', $template, $boolPattern);
 
@@ -164,7 +167,8 @@ class Mustache
             elseif ($val instanceof \Closure)
             {
                 // set closure return
-                $template = str_replace('{{' . $key . '}}', $val(), $template);
+                $template = str_replace('{{{' . $key . '}}}', $val(), $template);
+                $template = str_replace('{{' . $key . '}}', htmlspecialchars($val()), $template);
             }
 
             // ----------------------------------

--- a/src/Mustache.php
+++ b/src/Mustache.php
@@ -133,6 +133,11 @@ class Mustache
                 }
             }
 
+            else if (is_array($val) && empty($val) === true) {
+                // remove
+                $template = preg_replace('|{{#' . $key . '}}(.*?){{/' . $key . '}}|sm', '', $template);
+            }
+
             // ----------------------------------
 
             elseif (is_bool($val) || is_array($val) && empty($val) === true)


### PR DESCRIPTION
`finaliseTemplate` is buggy. Consider the following context and mustache file:

``` php
[ 'foo' => false, 'bar' => false ]
```

```
{{#foo}}
Show some text foo. {{#bar}}Show bar.{{/bar}} Some other foo.
{{/foo}}
```

Then neither `foo` nor `bar` will be touched by `parse`. However `finaliseTemplate` will return:

```
 Some other foo.
```

Due to the lazy operator `?` only the part between `{{#foo}}` and `{{/bar}}` gets erased. The solution is to check for matching handles in `parse`.
